### PR TITLE
Refactored layouts to consider popularity

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -7,7 +7,8 @@ require.config({
 		es5shim: 'components/es5-shim/es5-shim',
 		es5sham: 'components/es5-shim/es5-sham',
 		text: 'components/text/text',
-		sylvester: 'components/sylvester/sylvester'
+		sylvester: 'components/sylvester/sylvester',
+		underscore: 'components/underscore/underscore'
 	},
 	map: {
 		'*': {
@@ -16,7 +17,7 @@ require.config({
 	},
 	shim: {
 		'components/flight/lib/index': {
-			deps: ['jquery', 'es5shim', 'es5sham']
+			deps: ['jquery', 'es5shim', 'es5sham', 'underscore']
 		},
 		'app/js/app': {
 			deps: ['components/flight/lib/index']

--- a/app/js/ui/tileGroup.js
+++ b/app/js/ui/tileGroup.js
@@ -59,6 +59,7 @@ define(
 				}
 
 				// Render every tile.
+				this.$node.html('');
 				_.map(tiles, function(tile){ _this.render(e, {tile: tile}); });
 
 				// Compute the optimal arrangement

--- a/component.json
+++ b/component.json
@@ -5,6 +5,7 @@
 		"flight": "~1.0.0",
 		"requirejs": "2.1.5",
 		"text": "git@github.com:requirejs/text.git",
-		"sylvester": "0.1.3"
+		"sylvester": "0.1.3",
+    "underscore": "components/underscore/index.js"
 	}
 }


### PR DESCRIPTION
Considers popularity when deciding on tile sizes. More popular -> larger tile.
### Notes
- Added underscore.js
- The prior layout representation lacked a representation of position/ordering, leading tiles to be visually grouped by size. This new representation allows control over not only block sizes, but also insertion order. I've included a couple sample layouts.
- We no longer checks for specific size strings, allowing one to resize blocks to their heart's desire.
